### PR TITLE
Update the plugin for supporting macos arm architecture (m1 & m2) 

### DIFF
--- a/bin/devcontainer_setup_scripts/root_setup.sh
+++ b/bin/devcontainer_setup_scripts/root_setup.sh
@@ -44,17 +44,26 @@ if ! type nvim >/dev/null 2>&1; then
 
 	# Installing neovim via appimage. Recommended approach: https://github.com/neovim/neovim/releases/download/v0.9.1/nvim-linux64.deb
 	# curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage
-	curl -LO https://github.com/neovim/neovim/releases/download/v0.8.3/nvim.appimage
-	chmod u+x nvim.appimage
-	./nvim.appimage --appimage-extract
-	./squashfs-root/AppRun --version
-	rm nvim.appimage
+	#
+	# curl -LO https://github.com/neovim/neovim/releases/download/v0.8.3/nvim.appimage
+	# chmod u+x nvim.appimage
+	# ./nvim.appimage --appimage-extract
+	# ./squashfs-root/AppRun --version
+	# rm nvim.appimage
 
 	# Exposing nvim globally
-	if [ ! -d /squashfs-root ]; then
-		mv squashfs-root /
-	fi
-	ln -s /squashfs-root/AppRun /usr/bin/nvim
+	# if [ ! -d /squashfs-root ]; then
+	# 	mv squashfs-root /
+	# fi
+	# ln -s /squashfs-root/AppRun /usr/bin/nvim
+
+	# Steps defined here: https://dev.to/asyncedd/building-neovim-from-source-1794
+	apt-get update
+	apt-get install -y ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen
+	git clone https://github.com/neovim/neovim.git
+	cd neovim
+	make CMAKE_BUILD_TYPE=RelWithDebInfo
+	make install
 
 	# Forcing ~/.config/ accessible by my-app user
 	if [ ! -d /home/my-app/.config ]; then

--- a/bin/devcontainer_setup_scripts/root_setup.sh
+++ b/bin/devcontainer_setup_scripts/root_setup.sh
@@ -9,6 +9,8 @@ fi
 
 if ! type nvim >/dev/null 2>&1; then
 	# Updating libraries to ensure nodejs >= 14 is being installed.
+	cd "${HOME}"
+
 	apt-get update
 	apt-get install -y curl wget
 	curl -sL https://deb.nodesource.com/setup_18.x | bash -
@@ -33,37 +35,40 @@ if ! type nvim >/dev/null 2>&1; then
 	install lazygit /usr/local/bin
 	rm lazygit.tar.gz lazygit
 
-	# Installing neovim via .deb
-	# curl -LO https://github.com/neovim/neovim/releases/download/v0.9.1/nvim-linux64.deb
-	# apt install ./nvim-linux64.deb
-	# rm ./nvim-linux64.deb
-
+	NVIM_VERSION=v0.8.3
 	# .deb is not supported for 0.9.0 version upwards. More info: https://github.com/neovim/neovim/issues/22684
 	# Another options for installing neovim:
 	# https://github.com/MordechaiHadad/bob
 
-	# Installing neovim via appimage. Recommended approach: https://github.com/neovim/neovim/releases/download/v0.9.1/nvim-linux64.deb
-	# curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage
-	#
-	# curl -LO https://github.com/neovim/neovim/releases/download/v0.8.3/nvim.appimage
-	# chmod u+x nvim.appimage
-	# ./nvim.appimage --appimage-extract
-	# ./squashfs-root/AppRun --version
-	# rm nvim.appimage
+	# Install neovim in the way above only for ARM architectures
+	if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm" ]; then
+		# Steps defined here: https://dev.to/asyncedd/building-neovim-from-source-1794
+		apt-get update
+		apt-get install -y ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen
+		git clone https://github.com/neovim/neovim.git
+		# Versions higher than v0.8.3 present visualization problems when connected inside neovim
+		cd neovim
+		git checkout ${NVIM_VERSION}
+		make CMAKE_BUILD_TYPE=RelWithDebInfo
+		make install
+		cd -
+		rm -rf neovim
+	else
+		# Installing neovim via appimage. Recommended approach: https://github.com/neovim/neovim/releases/download/v0.9.1/nvim-linux64.deb
+		# curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage
 
-	# Exposing nvim globally
-	# if [ ! -d /squashfs-root ]; then
-	# 	mv squashfs-root /
-	# fi
-	# ln -s /squashfs-root/AppRun /usr/bin/nvim
+		curl -LO https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim.appimage
+		chmod u+x nvim.appimage
+		./nvim.appimage --appimage-extract
+		./squashfs-root/AppRun --version
+		rm nvim.appimage
 
-	# Steps defined here: https://dev.to/asyncedd/building-neovim-from-source-1794
-	apt-get update
-	apt-get install -y ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen
-	git clone https://github.com/neovim/neovim.git
-	cd neovim
-	make CMAKE_BUILD_TYPE=RelWithDebInfo
-	make install
+		# Exposing nvim globally
+		if [ ! -d /squashfs-root ]; then
+			mv squashfs-root /
+		fi
+		ln -s /squashfs-root/AppRun /usr/bin/nvim
+	fi
 
 	# Forcing ~/.config/ accessible by my-app user
 	if [ ! -d /home/my-app/.config ]; then
@@ -75,6 +80,12 @@ if ! type nvim >/dev/null 2>&1; then
 		mkdir /home/my-app/.local
 	fi
 
+	# Forcing ~/.cache/ accessible by my-app user
+	if [ ! -d /home/my-app/.cache ]; then
+		mkdir /home/my-app/.cache
+	fi
+
 	chown -R my-app:my-app /home/my-app/.config
 	chown -R my-app:my-app /home/my-app/.local
+	chown -R my-app:my-app /home/my-app/.cache
 fi

--- a/bin/spawn_devcontainer.sh
+++ b/bin/spawn_devcontainer.sh
@@ -3,18 +3,42 @@ set -xe
 # Function which provides the folder where the .git folder is located
 # In case there is no git initialized it will return an error
 
+# Bash script provides 2 arguments, the first is for removing the existing container (if any), and the secondone the env (dev, pro)
+# Default values
+remove_existing_container=""
+env="pro"
+
+# Handle command-line arguments
+while [ $# -gt 0 ]; do
+	case $1 in
+	-r | --remove-existing-container)
+		remove_existing_container="--remove-existing-container"
+		shift
+		;;
+	-e | --env)
+		if [ "$2" = "dev" ]; then
+			env="dev"
+		elif [ "$2" = "pro" ]; then
+			env="pro"
+		else
+			echo "Invalid env. Please specify either 'dev' or 'pro' for -e."
+			exit 1
+		fi
+		shift 2
+		;;
+	*)
+		echo "Invalid option: $1"
+		exit 1
+		;;
+	esac
+done
+
 get_project_root_folder() {
 	git rev-parse --show-toplevel
 }
 
 workspace=$(get_project_root_folder)
 cd "${workspace}"
-
-remove_flag=""
-if [ "$1" = "true" ]; then
-	remove_flag="--remove-existing-container"
-	shift
-fi
 
 NVIM_DEVCONTAINER_CLI_FOLDER=$(echo "${HOME}"/.local/share/nvim/lazy/nvim-devcontainer-cli/ | sed "s|^$HOME||")
 HOME_IN_DOCKER_CONTAINER="/home/my-app/"
@@ -28,9 +52,13 @@ else
 	MOUNT_BIND_COPILOT="--mount type=bind,source=${HOME}/.config/github-copilot,target=/home/my-app/.config/github-copilot"
 fi
 
-devcontainer up $remove_flag \
+# Mount the plugin folder only if --env is set to dev:
+if [ "$env" = "dev" ]; then
+	MOUNT_BIND_PLUGIN="--mount type=bind,source=${HOME}/${NVIM_DEVCONTAINER_CLI_FOLDER},target=${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}"
+fi
+devcontainer up ${remove_existing_container} \
 	${MOUNT_BIND_COPILOT} \
-	--mount type=bind,source="${HOME}"/"${NVIM_DEVCONTAINER_CLI_FOLDER}",target="${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}" \
+	${MOUNT_BIND_PLUGIN} \
 	--workspace-folder "${workspace}"
 
 # Setting Up Devcontainer ()

--- a/bin/spawn_devcontainer.sh
+++ b/bin/spawn_devcontainer.sh
@@ -8,7 +8,7 @@ get_project_root_folder() {
 }
 
 workspace=$(get_project_root_folder)
-cd ${workspace}
+cd "${workspace}"
 
 remove_flag=""
 if [ "$1" = "true" ]; then
@@ -16,18 +16,18 @@ if [ "$1" = "true" ]; then
 	shift
 fi
 
-NVIM_DEVCONTAINER_CLI_FOLDER=$(echo ${HOME}/.local/share/nvim/lazy/nvim-devcontainer-cli/ | sed "s|^$HOME||")
+NVIM_DEVCONTAINER_CLI_FOLDER=$(echo "${HOME}"/.local/share/nvim/lazy/nvim-devcontainer-cli/ | sed "s|^$HOME||")
 HOME_IN_DOCKER_CONTAINER="/home/my-app/"
-NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER=${HOME_IN_DOCKER_CONTAINER}${NVIM_DEVCONTAINER_CLI_FOLDER}
+NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER=${HOME_IN_DOCKER_CONTAINER}"${NVIM_DEVCONTAINER_CLI_FOLDER}"
 DEVCONTAINER_OVERRIDE_CONFIG=.devcontainer/devcontainer-override.json
 
 devcontainer up $remove_flag \
 	--mount type=bind,source=${HOME}/.config/github-copilot,target=/home/my-app/.config/github-copilot \
-	--mount type=bind,source=${HOME}/${NVIM_DEVCONTAINER_CLI_FOLDER},target=${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER} \
-	--workspace-folder ${workspace}
+	--mount type=bind,source="${HOME}"/"${NVIM_DEVCONTAINER_CLI_FOLDER}",target="${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}" \
+	--workspace-folder "${workspace}"
 
 # Setting Up Devcontainer ()
 # TODO: Instead of having 2 different scripts (for root and not root users) we should have a unique script (simplifying the usage of the plugin)
-devcontainer exec --override-config ${DEVCONTAINER_OVERRIDE_CONFIG} --workspace-folder ${workspace} sh ${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}/bin/devcontainer_setup_scripts/root_setup.sh
+devcontainer exec --override-config ${DEVCONTAINER_OVERRIDE_CONFIG} --workspace-folder "${workspace}" sh "${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}"/bin/devcontainer_setup_scripts/root_setup.sh
 # Setting Up Devcontainer (no root permits)
-devcontainer exec --workspace-folder ${workspace} sh ${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}/bin/devcontainer_setup_scripts/none_root_setup.sh
+devcontainer exec --workspace-folder "${workspace}" sh "${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}"/bin/devcontainer_setup_scripts/none_root_setup.sh

--- a/bin/spawn_devcontainer.sh
+++ b/bin/spawn_devcontainer.sh
@@ -21,8 +21,15 @@ HOME_IN_DOCKER_CONTAINER="/home/my-app/"
 NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER=${HOME_IN_DOCKER_CONTAINER}"${NVIM_DEVCONTAINER_CLI_FOLDER}"
 DEVCONTAINER_OVERRIDE_CONFIG=.devcontainer/devcontainer-override.json
 
+# Check if file .config/github-copilot exists
+if [ ! -d "${HOME}"/.config/github-copilot ]; then
+	echo "File ${HOME}/.config/github-copilot does not exist"
+else
+	MOUNT_BIND_COPILOT="--mount type=bind,source=${HOME}/.config/github-copilot,target=/home/my-app/.config/github-copilot"
+fi
+
 devcontainer up $remove_flag \
-	--mount type=bind,source=${HOME}/.config/github-copilot,target=/home/my-app/.config/github-copilot \
+	${MOUNT_BIND_COPILOT} \
 	--mount type=bind,source="${HOME}"/"${NVIM_DEVCONTAINER_CLI_FOLDER}",target="${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}" \
 	--workspace-folder "${workspace}"
 

--- a/doc/devcontainer_cli.txt
+++ b/doc/devcontainer_cli.txt
@@ -5,7 +5,7 @@ nvim-devcontainer-cli is a nvim plugin which intends to use the devcontainer-cli
 developed by microsoft for creating your own local development environments when 
 developing docker containers. 
 
-Development is in progress.
+Development is in progress, but the plugin can already be used.
 
 To find out more:
 https://github.com/arnaupv/nvim-devcontainer-cli
@@ -15,6 +15,15 @@ https://github.com/arnaupv/nvim-devcontainer-cli
 DevcontainerUp                                                  *DevcontainerUp*
     Spawns a docker devcontainer, installing neovim and all the required 
     dependencies for developing your code inside the docker container.
+
+    Following arguments are accepted:
+    "dev":
+      nvim-devcontainer-cli plugin mounted in the devcontainer. This is only needed
+      if you are developing the plugin itself, as the changes inside the container
+      wil be reflected in the host.
+
+    "pro": [default_value]
+      nvim-devcontainer-cli plugin not mount in the devcontainer
 
 
 DevcontainerConnect                                        *DevcontainerConnect*

--- a/lua/devcontainer_cli/devcontainer_cli.lua
+++ b/lua/devcontainer_cli/devcontainer_cli.lua
@@ -6,6 +6,7 @@ local M = {}
 local config = {
   devcontainer_folder = ".devcontainer/",
   nvim_plugin_folder = "~/.local/share/nvim/lazy/nvim-devcontainer-cli/",
+  remove_existing_container = true,
 }
 
 local function define_autocommands()
@@ -42,7 +43,13 @@ function M.up(user_config)
     print("Devcontainer folder detected. Path: " .. config.devcontainer_folder)
   end
 
-  local command = config.nvim_plugin_folder .. "/bin/spawn_devcontainer.sh true"
+  local command = config.nvim_plugin_folder .. "/bin/spawn_devcontainer.sh"
+
+  if config.remove_existing_container then
+    command = command .. " --remove-existing-container"
+  end
+  command = command .. " -e " .. config.env
+
   windows_utils.create_floating_terminal(command, {
     on_success = function(win_id)
       vim.notify("A devcontainer has been successfully spawn by the nvim-devcontainer-cli!", vim.log.levels.INFO)

--- a/lua/devcontainer_cli/init.lua
+++ b/lua/devcontainer_cli/init.lua
@@ -13,11 +13,16 @@ function M.setup()
   configured = true
 
   -- Docker
-  vim.api.nvim_create_user_command("DevcontainerUp", function(_)
-    devcontainer_cli.up()
+  vim.api.nvim_create_user_command("DevcontainerUp", function(opts)
+    local env = opts.args or "pro"
+    devcontainer_cli.up({ env = env, remove_existing_container = true })
   end, {
-    nargs = 0,
+    nargs = "*",
     desc = "Up devcontainer using .devcontainer.json",
+    complete = function(ArgLead, CmdLine, CursorPos)
+      -- return completion candidates as a list-like table
+      return { "dev", "pro" }
+    end,
   })
 
   vim.api.nvim_create_user_command("DevcontainerConnect", function(_)


### PR DESCRIPTION
In this case the nvim is installed from the source code instead of being installed by the nvim.appimage (more info [here](https://github.com/arnaupv/nvim-devcontainer-cli/issues/9#issuecomment-1612963464)). 

In this way, nvim is installed adapted to the given architecture. As a consequence, extra dependencies are needed and it makes the devcontainers bigger in size. 