### PR TITLE
Making the config configurable from the "opts" field in the plugin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,24 @@ This plugin has been inspired by the work previously done by [esensar](https://g
 ```lua
 {
   "arnaupv/nvim-devcontainer-cli",
-  opts = {}
+  opts = {},
+  keys = {
+    -- stylua: ignore
+    {
+      "<leader>cdu",
+      ":DevcontainerUp pro<cr>",
+      desc = "Up the DevContainer",
+    },
+    {
+      "<leader>cdc",
+      ":DevcontainerConnect<cr>",
+      desc = "Connect to DevContainer",
+    },
+  }
 },
 ```
+
+The default_config can be found [here](./lua/devcontainer_cli/config/init.lua).
 
 # How to use?
 
@@ -93,5 +108,4 @@ make test
 1. [ ] [Give the possibility of defining custom dotfiles when setting up the devcontainer](https://github.com/arnaupv/nvim-devcontainer-cli/issues/1)
 1. [ ] Detect the cause/s of the UI issues of neovim when running inside the docker container.
 1. [ ] Convert bash scripts in lua code.
-1. [ ] Currently bash scripts only support Ubuntu (OS). Once the code is migrated to lua, it has to cover the installation other OS.
 1. [ ] Create .devcontainer/devcontainer.json template automatically via a nvim command. Add examples for when the devcontainer is created from docker and also from docker-compose.

--- a/doc/devcontainer_cli.txt
+++ b/doc/devcontainer_cli.txt
@@ -16,16 +16,6 @@ DevcontainerUp                                                  *DevcontainerUp*
     Spawns a docker devcontainer, installing neovim and all the required 
     dependencies for developing your code inside the docker container.
 
-    Following arguments are accepted:
-    "dev":
-      nvim-devcontainer-cli plugin mounted in the devcontainer. This is only needed
-      if you are developing the plugin itself, as the changes inside the container
-      wil be reflected in the host.
-
-    "pro": [default_value]
-      nvim-devcontainer-cli plugin not mount in the devcontainer
-
-
 DevcontainerConnect                                        *DevcontainerConnect*
     Closes the nvim sessions (all sessions fromt the terminal) and opens a new
     terminal which is connected in the docker container, ready to execute the

--- a/lua/devcontainer_cli/config/init.lua
+++ b/lua/devcontainer_cli/config/init.lua
@@ -1,0 +1,37 @@
+local ConfigModule = {}
+
+local default_config = {
+  --[[
+    "dev":
+    nvim-devcontainer-cli plugin mounted in the devcontainer. This is only needed
+    if you are developing the plugin itself, as the changes inside the container
+    wil be reflected in the host.
+
+    "pro": [default_value]
+    nvim-devcontainer-cli plugin not mount in the devcontainer.
+  --]]
+  env = "pro", -- Options: pro/dev
+  -- Folder where devcontainer tool looks for the devcontainer.json file
+  devcontainer_folder = ".devcontainer/",
+  -- Folder where the nvim-devcontainer-cli is installed
+  nvim_plugin_folder = "~/.local/share/nvim/lazy/nvim-devcontainer-cli/",
+  -- Remove existing container each time DevcontainerUp is executed
+  -- If set to True [default_value] it can take extra time as you force to start from scratch
+  remove_existing_container = true,
+}
+
+local options
+
+function ConfigModule.setup(opts)
+  opts = vim.tbl_deep_extend("force", default_config, opts or {})
+  options = opts
+end
+
+return setmetatable(ConfigModule, {
+  __index = function(_, key)
+    if options == nil then
+      return vim.deepcopy(default_config)[key]
+    end
+    return options[key]
+  end,
+})

--- a/lua/devcontainer_cli/devcontainer_cli.lua
+++ b/lua/devcontainer_cli/devcontainer_cli.lua
@@ -1,13 +1,8 @@
+local config = require("devcontainer_cli.config")
 local windows_utils = require("devcontainer_cli.windows_utils")
 local folder_utils = require("devcontainer_cli.folder_utils")
 
 local M = {}
-
-local config = {
-  devcontainer_folder = ".devcontainer/",
-  nvim_plugin_folder = "~/.local/share/nvim/lazy/nvim-devcontainer-cli/",
-  remove_existing_container = true,
-}
 
 local function define_autocommands()
   local au_id = vim.api.nvim_create_augroup("devcontainer.docker.terminal", {})
@@ -25,13 +20,7 @@ local function define_autocommands()
   })
 end
 
-function M.up(user_config)
-  user_config = user_config or {}
-
-  for option, value in pairs(user_config) do
-    config[option] = value
-  end
-
+function M.up()
   if not folder_utils.folder_exists(config.devcontainer_folder) then
     print(
       "Devcontainer folder not available: "
@@ -50,6 +39,7 @@ function M.up(user_config)
   end
   command = command .. " -e " .. config.env
 
+  print("Spawning devcontainer. Command: " .. command)
   windows_utils.create_floating_terminal(command, {
     on_success = function(win_id)
       vim.notify("A devcontainer has been successfully spawn by the nvim-devcontainer-cli!", vim.log.levels.INFO)

--- a/lua/devcontainer_cli/init.lua
+++ b/lua/devcontainer_cli/init.lua
@@ -1,10 +1,12 @@
 local M = {}
 
 local devcontainer_cli = require("devcontainer_cli.devcontainer_cli")
-
+local config = require("devcontainer_cli.config")
 local configured = false
 
-function M.setup()
+function M.setup(opts)
+  config.setup(opts)
+
   if configured then
     print("Already configured, skipping!")
     return
@@ -14,15 +16,11 @@ function M.setup()
 
   -- Docker
   vim.api.nvim_create_user_command("DevcontainerUp", function(opts)
-    local env = opts.args or "pro"
-    devcontainer_cli.up({ env = env, remove_existing_container = true })
+    -- Try to use opts.args and if empty use "pro"
+    devcontainer_cli.up()
   end, {
-    nargs = "*",
-    desc = "Up devcontainer using .devcontainer.json",
-    complete = function(ArgLead, CmdLine, CursorPos)
-      -- return completion candidates as a list-like table
-      return { "dev", "pro" }
-    end,
+    nargs = 0,
+    desc = "Up devcontainer using .devcontainer/devcontainer.json",
   })
 
   vim.api.nvim_create_user_command("DevcontainerConnect", function(_)


### PR DESCRIPTION
This fixes the issue reported in #5 regarding default env values and also makes the plugin default_config configurable from the plugin definition. For instance:
```lua
{
  "arnaupv/nvim-devcontainer-cli",
  opts = {
    env = "pro",
  },
}
```
The default configs can be found [here](https://github.com/arnaupv/nvim-devcontainer-cli/pull/12/files#diff-3735609934b79fe57a5e703c69672c8bbdb5ee30297b93d9869d0b0f8486a243R3-R21)
