### PR TITLE
Dotfiles can be defined as config parameter when setting up the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,18 @@ This plugin has been inspired by the work previously done by [esensar](https://g
 ```lua
 {
   "arnaupv/nvim-devcontainer-cli",
-  opts = {},
+  opts = {
+    -- By default, if no extra config is added, following nvim_dotfiles are
+    -- installed: "https://github.com/LazyVim/starter"
+    -- This is an example for configuring other nvim_dotfiles inside the docker container
+    nvim_dotfiles = "https://github.com/arnaupv/dotfiles.git",
+    nvim_dotfiles_install = "cd ~/dotfiles/ && ./install.sh",
+  },
   keys = {
     -- stylua: ignore
     {
       "<leader>cdu",
-      ":DevcontainerUp pro<cr>",
+      ":DevcontainerUp<cr>",
       desc = "Up the DevContainer",
     },
     {

--- a/bin/devcontainer_setup_scripts/none_root_setup.sh
+++ b/bin/devcontainer_setup_scripts/none_root_setup.sh
@@ -1,14 +1,37 @@
 #!/bin/sh
 set -xe
 
+# Check if I'm connected as root user. If yes, exit.
+if [ "$(id -u)" = "0" ]; then
+	echo "Sorry, you are not root."
+	exit 1
+fi
+
+while [ $# -gt 0 ]; do
+	case $1 in
+	-d | --dotfiles)
+		nvim_dotfiles=$2
+		shift 2
+		;;
+	-i | --install_command)
+		nvim_dotfiles_install=$2
+		shift 2
+		;;
+	*)
+		echo "Invalid option: $1"
+		exit 1
+		;;
+	esac
+done
+
 MY_HOME=${HOME} # /root/
 
 # TODO: Installing my dotfiles. Instead of having this part of the code hardcoded, this config param has to be as a plugin config param.
 # If dotfiles folder does not exist in MY_HOME directory, clone the repo and run install.sh script.
 if [ ! -d "${MY_HOME}"/dotfiles ]; then
-	git clone https://github.com/arnaupv/dotfiles.git "${MY_HOME}"/dotfiles
-	cd "${MY_HOME}"/dotfiles
-	./install.sh
+	git clone "${nvim_dotfiles}" "${MY_HOME}"/dotfiles
+	cd "${MY_HOME}"/
+	eval "${nvim_dotfiles_install}"
 	cd -
 fi
 

--- a/bin/spawn_devcontainer.sh
+++ b/bin/spawn_devcontainer.sh
@@ -26,6 +26,14 @@ while [ $# -gt 0 ]; do
 		fi
 		shift 2
 		;;
+	-d | --dotfiles)
+		nvim_dotfiles=$2
+		shift 2
+		;;
+	-i | --install_command)
+		nvim_dotfiles_install=$2
+		shift 2
+		;;
 	*)
 		echo "Invalid option: $1"
 		exit 1
@@ -65,4 +73,4 @@ devcontainer up ${remove_existing_container} \
 # TODO: Instead of having 2 different scripts (for root and not root users) we should have a unique script (simplifying the usage of the plugin)
 devcontainer exec --override-config ${DEVCONTAINER_OVERRIDE_CONFIG} --workspace-folder "${workspace}" sh "${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}"/bin/devcontainer_setup_scripts/root_setup.sh
 # Setting Up Devcontainer (no root permits)
-devcontainer exec --workspace-folder "${workspace}" sh "${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}"/bin/devcontainer_setup_scripts/none_root_setup.sh
+devcontainer exec --workspace-folder "${workspace}" sh "${NVIM_DEVCONTAINER_CLI_FOLDER_IN_DOCKER_CONTAINER}"/bin/devcontainer_setup_scripts/none_root_setup.sh -d "${nvim_dotfiles}" -i "${nvim_dotfiles_install}"

--- a/lua/devcontainer_cli/config/init.lua
+++ b/lua/devcontainer_cli/config/init.lua
@@ -18,6 +18,11 @@ local default_config = {
   -- Remove existing container each time DevcontainerUp is executed
   -- If set to True [default_value] it can take extra time as you force to start from scratch
   remove_existing_container = true,
+  -- nvim_dotfiles that will be installed inside the docker devcontainer throught the devcontainer cli.
+  -- [default_value] - LazyVim/starter
+  nvim_dotfiles = "https://github.com/LazyVim/starter",
+  -- nvim_dotfiles_install is the command that needs to be executed to install the dotfiles (it can be any bash command)
+  nvim_dotfiles_install = "mv ~/dotfiles ~/.config/nvim",
 }
 
 local options

--- a/lua/devcontainer_cli/devcontainer_cli.lua
+++ b/lua/devcontainer_cli/devcontainer_cli.lua
@@ -38,6 +38,8 @@ function M.up()
     command = command .. " --remove-existing-container"
   end
   command = command .. " -e " .. config.env
+  command = command .. " -d " .. config.nvim_dotfiles
+  command = command .. " -i " .. '"' .. config.nvim_dotfiles_install .. '"'
 
   print("Spawning devcontainer. Command: " .. command)
   windows_utils.create_floating_terminal(command, {

--- a/lua/devcontainer_cli/init.lua
+++ b/lua/devcontainer_cli/init.lua
@@ -15,7 +15,7 @@ function M.setup(opts)
   configured = true
 
   -- Docker
-  vim.api.nvim_create_user_command("DevcontainerUp", function(opts)
+  vim.api.nvim_create_user_command("DevcontainerUp", function(_)
     -- Try to use opts.args and if empty use "pro"
     devcontainer_cli.up()
   end, {


### PR DESCRIPTION
Following PR is not using the dotfiles config parameter from devcontainer-cli as it is commented in the following issue: #1
The purpose of this PR is to provide the dotifles config feature for increasing the usability of the plugin. At some point, the code will end up needing a refactoring and use the dofiles  env mentioned in #1, but in the meantime the dotfiles config feature can already be used.